### PR TITLE
Use a readable ID?

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -52,5 +52,5 @@
   }
   ],
 
-  "id": "jid0-GjwrPchS3Ugt7xydvqVK4DQk8Ls" 
+  "id": "GmailNotifier@inbasic.mozdev.org.xpi" 
 }


### PR DESCRIPTION
It's hard to navigate among files in the "%firefox_profile%\extensions\" folder just because some extensions have a non-readable IDs.
