### PR TITLE
Update tray.js

### DIFF
--- a/src/lib/wrapper/firefox/tray/winnt/tray.js
+++ b/src/lib/wrapper/firefox/tray/winnt/tray.js
@@ -215,7 +215,12 @@ exports.set = function (badge, msg) {
     return;
   }
   //nid.szInfo = msg;
-  nid.szTip = msg.substring(0, 63); // maximum of 64 characters
+  if (version >= 50) { //2K
+    nid.szTip = msg.substring(0, 127); // maximum of 128 characters
+  }
+  else {
+    nid.szTip = msg.substring(0, 63); // maximum of 64 characters
+  }
   icon(badge).then(function (arr) {
     var  uint8Array = new  Uint8Array(arr);
     nid.hIcon = user32.CreateIcon(hWnd, 16, 16, 1, 32, uint8Array, uint8Array);


### PR DESCRIPTION
Lift the character limitation. From [MSDN](https://msdn.microsoft.com/en-us/library/windows/desktop/bb773352.aspx):
> For Windows 2000 and later, szTip can have a maximum of 128 characters, including the terminating null character.

