### PR TITLE
Fixed Windows version detection

### DIFF
--- a/src/lib/wrapper/firefox/tray/winnt/tray.js
+++ b/src/lib/wrapper/firefox/tray/winnt/tray.js
@@ -12,7 +12,7 @@ var {Cc, Ci, Cu}  = require('chrome'),
     unload        = require('sdk/system/unload'),
     oscpu         = Cc['@mozilla.org/network/protocol;1?name=http']
       .getService(Ci.nsIHttpProtocolHandler).oscpu,
-    version       = parseInt((/\d\.\d/.exec(oscpu) || ['0'])[0].replace('.', '')), // Windows Version
+    version       = parseInt((/\d+\.\d+/.exec(oscpu) || ['0'])[0].replace('.', '')), // Windows Version
     config        = require('../../../../config');
 
 var exportsHelper = {};


### PR DESCRIPTION
Windows 10.0 was detected as 0.0. This is a followup for https://github.com/inbasic/ignotifier/pull/416.