### PR TITLE
icon for read

### DIFF
--- a/WebExtension/data/popup/index.css
+++ b/WebExtension/data/popup/index.css
@@ -253,8 +253,7 @@ footer div[name="refresh"] {
   background-image: url('icons/refresh.png');
 }
 footer div[name="read"] {
-  width: 90px;
-  background-image: none;
+  background-image: url('icons/check.png');
 }
 footer div[name="read-all"] {
   background-image: url('icons/check_all.png');


### PR DESCRIPTION
This is not a real PR: it's actually a question. Why is it that you don't use the check.png icon for "mark as read". Why do you keep the text?
Thanks