### PR TITLE
no age shaming

### DIFF
--- a/v3.classic/manifest.json
+++ b/v3.classic/manifest.json
@@ -3,7 +3,7 @@
   "description": "__MSG_description__",
   "author": "InBasic",
   "version": "1.1.3.3",
-  "minimum_chrome_version": "117",
+  "minimum_chrome_version": "1",
   "manifest_version": 3,
   "default_locale": "en",
   "permissions": [


### PR DESCRIPTION
users of old browsers might not use browser extensions or know what they are doing. if you fill in the blank, i can make another PR or commit like:  `chrome.runtime.onInstalled.addListener(function(installed){if(installed.reason=='install'){if 116 > Number(navigator.userAgent.match(new RegExp(Chrome + '/([0-9]+)'))){alert("[Just to make sure:] Some of our features might require chrome version 116+.... _______________________") }`    ( - or rather add it precisely, when that feature is first enabled as indicated by its button or storage change.)