### PR TITLE
Update messages.json for french translation

### DIFF
--- a/v1/src/_locales/fr/messages.json
+++ b/v1/src/_locales/fr/messages.json
@@ -1,6 +1,6 @@
 {
     "label_9": {
-        "message": "Pour 5 heures",        
+        "message": "Pour 5 heures",
         "description": ""
     },
     "options_notifications_19": {

--- a/v1/src/_locales/fr/messages.json
+++ b/v1/src/_locales/fr/messages.json
@@ -312,7 +312,7 @@
         "description": ""
     },
     "log_in_to_your_account": {
-        "message": "Veuillez vous connecter à votre compte Gmail",
+        "message": "Veuillez vous connecter à votre compte Gmail™",
         "description": ""
     },
     "popup_of": {
@@ -380,7 +380,7 @@
         "description": ""
     },
     "options_notifications_10": {
-        "message": "Note pour les utilisateurs de Mac. Depuis Firefox 28.0, toutes les notifications de bureau sont gérées par le \"Notification Center\" Mac qui provoque une alerte sonore supplémentaire. Vous devez désactiver soit cette notification sonore, soit celle générée par le \"Notification Center\".",
+        "message": "Remarque : pour les utilisateurs de Mac. Depuis Firefox 28.0, toutes les notifications de bureau sont gérées par le \"Notification Center\" Mac qui provoque une alerte sonore supplémentaire. Vous devez désactiver soit cette notification sonore, soit celle générée par le \"Notification Center\".",
         "description": ""
     },
     "options_misc_2": {
@@ -560,7 +560,7 @@
         "description": ""
     },
     "options_toolbar_17": {
-        "message": "Ouvrir le premier compte Gmail",
+        "message": "Ouvrir le premier compte Gmail™",
         "description": ""
     },
     "options_notifications_7": {
@@ -596,7 +596,7 @@
         "description": ""
     },
     "msg_4": {
-        "message": "Note : pour que le notifieur fonctionne correctement, vous devez être connecté à votre compte Google.",
+        "message": "Remarque : pour que le notifieur fonctionne correctement, vous devez être connecté à votre compte Google.",
         "description": ""
     },
     "popup_msg_20": {
@@ -660,7 +660,7 @@
         "description": ""
     },
     "options_inshort": {
-        "message": "Notifieur multi-comptes et multi-libellés pour Google Mail (Gmail).",
+        "message": "Notifieur multi-comptes et multi-libellés pour Google Mail (Gmail™).",
         "description": ""
     },
     "options_misc_12": {
@@ -676,11 +676,11 @@
         "description": ""
     },
     "label_12": {
-        "message": "Ouvrir la FAQs",
+        "message": "Ouvrir la FAQ",
         "description": ""
     },
     "description": {
-        "message": "Notifieur multi-comptes et multi-libellés pour Google Mail (Gmail)",
+        "message": "Notifieur multi-comptes et multi-libellés pour Google Mail (Gmail™)",
         "description": ""
     },
     "popup_spam": {

--- a/v1/src/_locales/fr/messages.json
+++ b/v1/src/_locales/fr/messages.json
@@ -1,6 +1,6 @@
 {
     "label_9": {
-        "message": "Pour 5 heures",ions_1
+        "message": "Pour 5 heures",
         
         "description": ""
     },

--- a/v1/src/_locales/fr/messages.json
+++ b/v1/src/_locales/fr/messages.json
@@ -1,6 +1,7 @@
 {
     "label_9": {
-        "message": "Pour 5 heures",
+        "message": "Pour 5 heures",ions_1
+        
         "description": ""
     },
     "options_notifications_19": {
@@ -320,7 +321,7 @@
         "description": ""
     },
     "options_notifications_15": {
-        "message": "Default sound notification is",
+        "message": "La notification sonore par défaut est",
         "description": ""
     },
     "options_notifications_21": {
@@ -380,7 +381,7 @@
         "description": ""
     },
     "options_notifications_10": {
-        "message": "Remarque : pour les utilisateurs de Mac. Depuis Firefox 28.0, toutes les notifications de bureau sont gérées par le \"Notification Center\" Mac qui provoque une alerte sonore supplémentaire. Vous devez désactiver soit cette notification sonore, soit celle générée par le \"Notification Center\".",
+        "message": "Remarque : pour les utilisateurs de Mac. Depuis Firefox 28.0, toutes les notifications de bureau sont gérées par le \" Centre de Notification\" Mac qui provoque une alerte sonore supplémentaire. Vous devez désactiver soit cette notification sonore, soit celle générée par le \"Centre de Notification\".",
         "description": ""
     },
     "options_misc_2": {

--- a/v1/src/_locales/fr/messages.json
+++ b/v1/src/_locales/fr/messages.json
@@ -268,7 +268,7 @@
         "description": ""
     },
     "options_tab_9": {
-        "message": "Lorsque cette option est décochée, le notifieur Gmail™ vérifie soit la fenêtre active, soit toutes les fenêtres ouvertes pour l'instance ouverte de Gmail™ et passe à l'onglet suivant lorsque l'ouverture d'onglet est demandée.",
+        "message": "Lorsque cette option est décochée, le notifieur Gmail™ vérifie la fenêtre active ou l'ensemble des fenêtres ouvertes pour l'instance en cours de Gmail™ et passe à l'onglet suivant lorsque l'ouverture d'onglet est demandée.",
         "description": ""
     },
     "gmail": {
@@ -376,11 +376,11 @@
         "description": ""
     },
     "options_notifications_24": {
-        "message": "Le volume est un nombre entre 0 et 100 où 100 est le volume le plus fort (défaut).",
+        "message": "Le volume est un nombre entre 0 et 100 où 100 est le volume le plus fort (par défaut).",
         "description": ""
     },
     "options_notifications_10": {
-        "message": "Remarque : pour les utilisateurs de Mac. Depuis Firefox 28.0, toutes les notifications de bureau sont gérées par le \" Centre de Notification\" Mac qui provoque une alerte sonore supplémentaire. Vous devez désactiver soit cette notification sonore, soit celle générée par le \"Centre de Notification\".",
+        "message": "Remarque : pour les utilisateurs de Mac. Depuis la version 28.0 de Firefox, toutes les notifications de bureau sont gérées par le \"Centre de Notifications\" Mac qui provoque une alerte sonore supplémentaire. Vous devez désactiver soit cette notification sonore, soit celle générée par le \"Centre de Notifications\".",
         "description": ""
     },
     "options_misc_2": {
@@ -636,7 +636,7 @@
         "description": ""
     },
     "options_gmail_2": {
-        "message": "Séparer les libellés par \",\" (Virgule).",
+        "message": "Séparer les libellés par \",\" (virgule).",
         "description": ""
     },
     "options_misc_4": {

--- a/v1/src/_locales/fr/messages.json
+++ b/v1/src/_locales/fr/messages.json
@@ -1,7 +1,6 @@
 {
     "label_9": {
-        "message": "Pour 5 heures",
-        
+        "message": "Pour 5 heures",        
         "description": ""
     },
     "options_notifications_19": {


### PR DESCRIPTION
Hello
Just one or two oversights for the French version. I will also look at the other "fr" files for v1 v2 v3

Regards

PS
I noticed that in my local zip file of the extension "jid0-GjwrPchS3Ugt7xydvqVK4DQk8Ls@jetpack.xpi" I do not have the same text present in the "message.json" part and the version of my file looks more recent! I am using "Notifier for Gmail™" version 1.1.6 of 03-08-2024