### PR TITLE
Update messages.json v2 (en) version

### DIFF
--- a/v2/_locales/en/messages.json
+++ b/v2/_locales/en/messages.json
@@ -20,6 +20,9 @@
   "log_in_to_your_account": {
     "message": "Please sign-in to your Gmail™ account"
   },
+  "popup_toggle_dark": {
+    "message": "Toggle dark theme on and off"
+  },
   "msg_1": {
     "message": "Tab is already open. Click on the toolbar button to open Gmail™ in a new tab, or to switch to an existing Gmail™ tab."
   },

--- a/v2/_locales/en/messages.json
+++ b/v2/_locales/en/messages.json
@@ -86,7 +86,7 @@
     "message": "unknown"
   },
   "and": {
-    "message": "and"
+    "message": " and "
   },
   "log_into_your_account": {
     "message": "Please log into your account"


### PR DESCRIPTION
Hi

I understood that the v2 file is no longer current but I did what was necessary in the v3 file and the problem on Transifex is the same.
I noticed that two lines are not translatable on Transifex and that they are missing in the English source file on Transifex. These are the lines:

  "popup_toggle_dark": {
    "message": "Toggle dark theme on and off"
  },

  "options_tab_11": {
    "message": "Open the newest unread email instead of opening the INBOX folder"
  },

For the line (option_tab_11) the line is already on Github but missed in Transifex.

I also saw that the term "and" is without a space before and after and that the text is less pretty. To avoid this I suggest putting a non-breaking space before and after (Alt255)

Regards