### PR TITLE
Update messages.json v3 for (en)

### DIFF
--- a/v3.classic/_locales/en/messages.json
+++ b/v3.classic/_locales/en/messages.json
@@ -83,7 +83,7 @@
     "message": "unknown"
   },
   "and": {
-    "message": "and"
+    "message": " and "
   },
   "log_into_your_account": {
     "message": "Please log into your account"


### PR DESCRIPTION

Hi

I noticed that two lines are not translatable on Transifex and that they are missing in the English source file on Transifex.  
These lines are the lines:

"popup_toggle_dark": {
"message": "Toggle dark theme on and off"
},

"options_tab_11": {
"message": "Open the newest unread email instead of opening the INBOX folder" },

The lines are already on Github v3 but missed in Transifex.

I also saw that the term "and" is without a space before and after and that the text is less pretty. 
To avoid this I suggest putting a non-breaking space before and after (Alt255)

I also updated the Italian translation on Transifex while noting that it was more than 2 years old and that it is no longer present on Github. 

Italian is also in fact not available on the plug-in and if we change the language of Chrome or Firefox the plug-in is then displayed in English.

Regards