### PR TITLE
Update messages.json V3 (en) version

### DIFF
--- a/v3.classic/_locales/en/messages.json
+++ b/v3.classic/_locales/en/messages.json
@@ -327,7 +327,7 @@
     "message": "Ignore opened Gmail™ tabs"
   },
   "options_tab_9": {
-    "message": "When unchecked, Gmail™ Notifier checks either active window or all open windows for open instance of Gmail™ and switch to the tab when tab opening is requested."
+    "message": "When checked, \"explain here what Notifier does\". When unchecked, Gmail™ Notifier checks either active window or all open windows for open instance of Gmail™ and switch to the tab when tab opening is requested."
   },
   "options_tab_10": {
     "message": "Open emails in basic HTML mode"
@@ -375,7 +375,7 @@
     "message": "Support keyboard shortcuts on the toolbar panel"
   },
   "options_toolbar_12": {
-    "message": "Report as spam: <!>, Trash: <#>, e: Archive: <e>, Mark as read: <Shift + i>."
+    "message": "Report as spam: < ! >, Trash: < # >, Archive: < e >, Mark as read: < Shift + i >."
   },
   "options_toolbar_13": {
     "message": "Render emails as HTML in full-content mode"


### PR DESCRIPTION
A small presentation change on the shortcuts and especially an addition that seems important to me.

When you have a choice to make it is important to know what happens in both cases (when the box is checked and when it is not) Of course you still have to indicate what Notifier does when the box is checked I suppose (Ignore all opened Gmail™ tabs and create a new tab or use the actual tab).

PS: I also noticed that the Italian language is present on Transifex but it is not on Github. As I speak a little Italian I updated the translation on Transifex but I do not know how to reintegrate this language on Github

Regards