### PR TITLE
Update messages.json V3 (fr) version

### DIFF
--- a/v3.classic/_locales/fr/messages.json
+++ b/v3.classic/_locales/fr/messages.json
@@ -272,7 +272,7 @@
         "description": ""
     },
     "options_notifications_11": {
-        "message": "Afficher la notification dans la barre de tâches Windows ou dans le dock Mac OS",
+        "message": "Afficher la notification dans la barre de tâches Windows™ ou dans le dock Mac OS",
         "description": ""
     },
     "options_notifications_12": {
@@ -280,7 +280,7 @@
         "description": ""
     },
     "options_notifications_13": {
-        "message": "Ouvrir le panneau de la barre d'outils sur clic de l'icône de notification dans la barre de tâches (uniquement sous Windows, beta)",
+        "message": "Ouvrir le panneau de la barre d'outils sur clic de l'icône de notification dans la barre de tâches (uniquement sous Windows™, beta)",
         "description": ""
     },
     "options_notifications_14": {
@@ -304,7 +304,7 @@
         "description": ""
     },
     "options_notifications_19": {
-        "message": "Alerte e-mail Windows",
+        "message": "Alerte e-mail Windows™",
         "description": ""
     },
     "options_notifications_20": {
@@ -332,7 +332,7 @@
         "description": ""
     },
     "options_notifications_26": {
-        "message": "Toujours afficher la notification dans la zone de notification système (uniquement sous Windows)",
+        "message": "Toujours afficher la notification dans la zone de notification système (uniquement sous Windows™)",
         "description": ""
     },
     "options_notifications_27": {

--- a/v3.classic/_locales/fr/messages.json
+++ b/v3.classic/_locales/fr/messages.json
@@ -2,757 +2,769 @@
     "gmail": {
         "message": "Notifieur pour Gmail™",
         "description": ""
-    },
+  },
     "toolbar_label": {
         "message": "Notifieur pour Gmail™",
         "description": ""
-    },
-    "tooltip_1": {
-        "message": "Clic gauche : Ouvrir Gmail™ ou le panneau de prévisualisation d'e-mail",
-        "description": ""
-    },
-    "tooltip_2": {
-        "message": "Clic milieu (ou Ctrl+clic gauche) : Rafraîchir tous les comptes",
-        "description": ""
-    },
-    "tooltip_3": {
-        "message": "Clic droit : Sélections des comptes",
-        "description": ""
-    },
+  },
     "description": {
         "message": "Notifieur multi-comptes et multi-libellés pour Google Mail (Gmail™)",
         "description": ""
-    },
+  },
     "log_in_to_your_account": {
         "message": "Veuillez vous connecter à votre compte Gmail™",
         "description": ""
-    },
+  },
     "msg_1": {
-        "message": "Un onglet est déjà ouvert. Cliquez sur le bouton de la barre d'outils pour ouvrir Gmail™ dans un nouvel onglet, ou pour basculer sur un onglet Gmail™ existant.",
+        "message": "L’onglet est déjà ouvert. Cliquez sur le bouton de la barre d’outils pour ouvrir Gmail™ dans un nouvel onglet ou pour passer à un onglet Gmail™ existant.",
         "description": ""
-    },
+  },
     "msg_2": {
-        "message": "Le lien est copié dans le presse-papiers.",
+        "message": "Le lien a été copié dans le presse-papiers.",
         "description": ""
-    },
+  },
     "msg_3": {
-        "message": "Le texte sélectionné est copié dans le presse-papiers.",
+        "message": "Le texte sélectionné a été copié dans le presse-papiers.",
         "description": ""
-    },
+  },
     "msg_4": {
-        "message": "Note : Pour que le notifieur fonctionne correctement, vous devez être connecté à votre compte Google.",
+        "message": "Remarque : pour que le notifieur fonctionne correctement, vous devez être connecté à votre compte Google.",
         "description": ""
-    },
+  },
     "msg_5": {
         "message": "Choisir un fichier son audio",
         "description": ""
-    },
+  },
     "label_1": {
         "message": "Rafraîchir",
         "description": ""
-    },
+  },
     "label_2": {
         "message": "Paramètres",
         "description": ""
-    },
+  },
     "label_3": {
         "message": "Désactiver toutes les notifications",
         "description": ""
-    },
+  },
     "label_4": {
         "message": "Pour 5 min",
         "description": ""
-    },
+  },
     "label_5": {
         "message": "Pour 15 min",
         "description": ""
-    },
+  },
     "label_6": {
         "message": "Pour 30 min",
         "description": ""
-    },
+  },
     "label_7": {
         "message": "Pour 1 heure",
         "description": ""
-    },
+  },
     "label_8": {
         "message": "Pour 2 heures",
         "description": ""
-    },
+  },
     "label_9": {
         "message": "Pour 5 heures",
         "description": ""
-    },
+  },
     "label_13": {
-        "message": "Pour une période de temps personnalisée",
+        "message": "Pour la période de temps personnalisée",
         "description": ""
-    },
+  },
     "label_10": {
         "message": "Activer les notifications (session)",
         "description": ""
-    },
+  },
     "label_11": {
         "message": "Rédiger un e-mail",
         "description": ""
-    },
+  },
     "label_12": {
         "message": "Ouvrir la FAQ",
         "description": ""
-    },
+  },
     "label_14": {
-        "message": "Comptes connectés",
+        "message": "Compte(s) connecté(s) :",
         "description": ""
-    },
+  },
     "unknown": {
         "message": "inconnu",
         "description": ""
-    },
+  },
     "and": {
         "message": "et",
         "description": ""
-    },
+  },
     "log_into_your_account": {
         "message": "Veuillez vous connecter à votre compte",
         "description": ""
-    },
+  },
     "notification": {
-        "message": "De : [author_email][break]Objet : [title][break]Résumé : [summary]",
+        "message": "De : [author_email][break] Objet : [title][break] Résumé : [summary]",
         "description": ""
-    },
+  },
     "options_title": {
-        "message": "Options - Gmail™ Notifieur",
+        "message": "Options - Gmail™ Notifier",
         "description": ""
-    },
+  },
     "options_inshort": {
         "message": "Notifieur multi-comptes et multi-libellés pour Google Mail (Gmail™).",
         "description": ""
-    },
+  },
     "options_donation": {
-        "message": "Faire un don",
+        "message": "Faire un don €",
         "description": ""
-    },
+  },
     "options_timings": {
-        "message": "Temporisations :",
+        "message": "Temporisations",
         "description": ""
-    },
+  },
     "options_timings_l1": {
-        "message": "Relever les nouveaux e-mails tous les (en secondes) :",
+        "message": "Relever les nouveaux e-mails toutes les (en secondes) :",
         "description": ""
-    },
+  },
     "options_timings_l2": {
         "message": "La période minimum est de 10 secondes.",
         "description": ""
-    },
+  },
     "options_timings_l3": {
         "message": "Rappeler les e-mails non lus toutes les (en minutes) :",
         "description": ""
-    },
+  },
     "options_timings_l4": {
         "message": "Positionner la valeur à zéro pour tous les rappels non périodiques.",
         "description": ""
-    },
+  },
     "options_timings_l5": {
         "message": "La période minimum est de 5 minutes.",
         "description": ""
-    },
+  },
     "options_timings_l6": {
-        "message": "Une valeur non nulle déclenche une notification sur le bureau et une alerte sonore (similaire à l'arrivée d'un nouvel e-mail) de façon perpétuelle si vous avez un ou plusieurs e-mails non lus.",
+        "message": "Une valeur non nulle déclenche une notification sur le bureau et une alerte sonore (similaire à l’arrivée d’un nouvel e-mail) et ce, de façon perpétuelle si vous avez un ou plusieurs e-mails non lus.",
         "description": ""
-    },
+  },
     "options_timings_l7": {
         "message": "Ne pas relever les nouveaux e-mails au démarrage avant (en secondes) :",
         "description": ""
-    },
+  },
     "options_timings_l8": {
-        "message": "Positionner la valeur à zéro pour éviter le relevé d'e-mails jusqu'au premier rafraîchissement manuel [Non disponible sous Safari].",
+        "message": "Positionner la valeur à zéro pour éviter le relevé d’e-mails jusqu’au premier rafraîchissement manuel [Non disponible avec Safari].",
         "description": ""
-    },
+  },
     "options_gmail": {
-        "message": "Gmail™ :",
+        "message": "Gmail™",
         "description": ""
-    },
+  },
     "options_gmail_1": {
         "message": "Compte principal (/mail/u/0/)",
         "description": ""
-    },
+  },
     "options_gmail_2": {
-        "message": "Séparer les libellés par \",\" (Virgule).",
+        "message": "Séparer les libellés par des \",\" (virgules).",
         "description": ""
-    },
+  },
     "options_gmail_3": {
         "message": "2ème compte (/mail/u/1/)",
         "description": ""
-    },
+  },
     "options_gmail_4": {
         "message": "3ème compte (/mail/u/2/)",
         "description": ""
-    },
+  },
     "options_gmail_5": {
         "message": "4ème compte (/mail/u/3/)",
         "description": ""
-    },
+  },
     "options_gmail_6": {
         "message": "5ème compte (/mail/u/4/)",
         "description": ""
-    },
+  },
     "options_gmail_7": {
         "message": "6ème compte (/mail/u/5/)",
         "description": ""
-    },
+  },
     "options_gmail_8": {
-        "message": "Marquer le message comme lu en l'archivant",
+        "message": "Marquer les messages comme lus en les archivant",
         "description": ""
-    },
+  },
     "options_gmail_15": {
         "message": "Quelques libellés populaires :",
         "description": ""
-    },
+  },
     "options_gmail_10": {
         "message": "Recevoir les notifications pour les libellés et comptes suivants :",
         "description": ""
-    },
+  },
     "options_gmail_11": {
         "message": "Flux personnalisés :",
         "description": ""
-    },
+  },
     "options_gmail_12": {
-        "message": "Séparer les flux par \",\" (Virgule). Exemple de flux : https://mail.google.com/mail/u/0/feed/atom/inbox",
+        "message": "Séparer les flux par des \",\" (virgules). Exemple de flux : https://mail.google.com/mail/u/0/feed/atom/inbox",
         "description": ""
-    },
+  },
     "options_gmail_13": {
-        "message": "Remarque : le nombre maximal pour tous les libellés sauf \"Boîte de réception\" est de 20 (les flux Google ne fournissent que les 20 entrées les plus récentes)",
+        "message": "Remarque : le nombre maximal pour tous les libellés sauf «Boîte de réception» est de 20 (les flux Google ne fournissent que les 20 entrées les plus récentes)",
         "description": ""
-    },
+  },
     "options_gmail_14": {
-        "message": "Remarque : pour que le notificateur écoute plus de 5 comptes, ajoutez les URL des flux au champ \"Flux personnalisés\". Par exemple, pour écouter les 6e et 7e comptes, ajoutez : https://mail.google.com/mail/u/6/feed/atom/inbox, https://mail.google.com/mail/u/7/feed/atom/inbox",
+        "message": "Remarque : pour que le notifieur écoute plus de 5 comptes, ajoutez les URL des flux au champ «Flux personnalisés». Par exemple, pour écouter les 6e et 7e comptes, ajoutez : https://mail.google.com/mail/u/6/feed/atom/inbox, https://mail.google.com/mail/u/7/feed/atom/inbox",
         "description": ""
-    },
+  },
     "options_notifications": {
-        "message": "Notifications :",
+        "message": "Notifications",
         "description": ""
-    },
+  },
     "options_notifications_1": {
         "message": "Afficher la notification sur le bureau pour les nouveaux e-mails",
         "description": ""
-    },
+  },
     "options_notifications_2": {
         "message": "Présenter la notification de bureau pendant (en secondes) :",
         "description": ""
-    },
+  },
     "options_notifications_3": {
-        "message": "Cette option peut ne pas fonctionner sur votre système d'exploitation.",
+        "message": "Cette option peut ne pas fonctionner sur votre système d’exploitation.",
         "description": ""
-    },
+  },
     "options_notifications_4": {
         "message": "Format de notification",
         "description": ""
-    },
+  },
     "options_notifications_5": {
         "message": "Variables disponibles :",
         "description": ""
-    },
+  },
     "options_notifications_6": {
-        "message": "Tronquer les notifications plus longues que",
+        "message": "Tronquer les notifications plus longues que ",
         "description": ""
-    },
+  },
     "options_notifications_7": {
-        "message": "caractères pour les champs [objet] et [résumé].",
+        "message": " caractères pour les champs [objet] et [résumé].",
         "description": ""
-    },
+  },
     "options_notifications_8": {
         "message": "Pour ne pas tronquer avec des points de suspension, utiliser un nombre élevé.",
         "description": ""
-    },
+  },
     "options_notifications_9": {
-        "message": "Jouer l'alerte sonore pour les nouveaux e-mails",
+        "message": "Jouer l’alerte sonore pour les nouveaux e-mails",
         "description": ""
-    },
+  },
     "options_notifications_10": {
-        "message": "Remarque : pour les utilisateurs de Mac. Depuis la version 28.0 de Firefox, toutes les notifications de bureau sont gérées par le \"Centre de Notifications\" Mac qui provoque une alerte sonore supplémentaire. Vous devez désactiver soit cette notification sonore, soit celle générée par le \"Centre de Notifications\".",
+        "message": "Remarque : pour les utilisateurs de Mac. Depuis la version 28.0 de Firefox, toutes les notifications de bureau sont gérées par le «Centre de notifications» Mac qui provoque une alerte sonore supplémentaire. Vous devez désactiver soit cette notification sonore, soit celle générée par le «Centre de notifications».",
         "description": ""
-    },
+  },
     "options_notifications_11": {
         "message": "Afficher la notification dans la barre de tâches Windows™ ou dans le dock Mac OS",
         "description": ""
-    },
+  },
     "options_notifications_12": {
         "message": "Les notifications dans la barre de tâches ne sont pas supportées sous Linux pour le moment.",
         "description": ""
-    },
+  },
     "options_notifications_13": {
-        "message": "Ouvrir le panneau de la barre d'outils sur clic de l'icône de notification dans la barre de tâches (uniquement sous Windows™, beta)",
+        "message": "Ouvrir le panneau de la barre d’outils par un clic sur  l’icône de notification dans la barre de tâches (uniquement sous Windows™, beta)",
         "description": ""
-    },
+  },
     "options_notifications_14": {
-        "message": "Cette fonctionnalité est hautement expérimentale et pourrait rendre instable votre navigateur Firefox. [Rédemarrage nécessaire].",
+        "message": "Cette fonctionnalité est hautement expérimentale et pourrait rendre instable votre navigateur Firefox. [Redémarrage nécessaire].",
         "description": ""
-    },
+  },
     "options_notifications_15": {
-        "message": "La notification sonore par défaut est",
+        "message": "La Notification sonore par défaut :",
         "description": ""
-    },
+  },
     "options_notifications_16": {
-        "message": "Alerte par défaut Gmail™ Notifier",
+        "message": "Alerte par défaut de Gmail™ Notifier",
         "description": ""
-    },
+  },
     "options_notifications_17": {
-        "message": "Alerte sonore \"Bell\" de l'extension \"Checker Plus\" pour Google Chrome",
+        "message": "Alerte «Bell» de Chrome «Checker Plus»",
         "description": ""
-    },
+  },
     "options_notifications_18": {
-        "message": "Alerte sonore \"Ding\" de l'extension \"Checker Plus\" pour Google Chrome",
+        "message": "Alerte «Ding» de Chrome «Checker Plus»",
         "description": ""
-    },
+  },
     "options_notifications_19": {
-        "message": "Alerte e-mail Windows™",
+        "message": "Alerte sonore Windows™ Mail ",
         "description": ""
-    },
+  },
     "options_notifications_20": {
-        "message": "Son défini par l'utilisateur",
+        "message": "Son défini par l’utilisateur",
         "description": ""
-    },
+  },
     "options_notifications_21": {
-        "message": "La notification sonore définie par l'utilisateur est",
+        "message": "Notification sonore définie par l’utilisateur :",
         "description": ""
-    },
+  },
     "options_notifications_22": {
-        "message": "Si votre navigateur ne lit pas le son de notification personnalisé, essayez de le convertir en un format WAV simple à l'aide d'un outil de conversion en ligne.",
+        "message": "Si votre navigateur ne lit pas le son de notification personnalisé, essayez de le convertir en un format WAV simple à l’aide d’un outil de conversion en ligne.",
         "description": ""
-    },
+  },
+    "options_notifications_35": {
+        "message": "Pour sélectionner un nouveau son personnalisé, sélectionnez d’abord un son intégré, puis modifiez le choix de l’option en son personnalisé.",
+        "description": ""
+  },
     "options_notifications_23": {
-        "message": "Le volume de la notification sonore est",
+        "message": "Le Volume de la notification sonore (en %) :",
         "description": ""
-    },
+  },
     "options_notifications_24": {
-        "message": "Le volume est un nombre entre 0 et 100 où 100 est le volume le plus fort (défaut).",
+        "message": "Le volume est un nombre entre 0 et 100 (%). 100 % est le volume le plus fort (par défaut).",
         "description": ""
-    },
+  },
     "options_notifications_25": {
-        "message": "Dans Safari, il est probable que les notfications sonores par défaut ne soient pas jouées correctement. Si c'est le cas, utilisez un fichier son personnel comme notification.",
+        "message": "Dans Safari, il est probable que les notifications sonores par défaut ne soient pas jouées correctement. Si c’est le cas, utilisez un fichier son personnel comme notification.",
         "description": ""
-    },
+  },
     "options_notifications_26": {
-        "message": "Toujours afficher la notification dans la zone de notification système (uniquement sous Windows™)",
+        "message": "Toujours afficher la notification dans la barre des taches (uniquement sous Windows™)",
         "description": ""
-    },
+  },
     "options_notifications_27": {
-        "message": "La notification dans la zone de notification système sera affichée même si tous les messages sont lus.",
+        "message": "La notification dans la barre des taches sera affichée même si tous les messages sont lus.",
         "description": ""
-    },
+  },
     "options_notifications_28": {
         "message": "Désactiver toutes les notifications pendant une période de temps personnalisée (en minutes) :",
         "description": ""
-    },
+  },
     "options_notifications_29": {
-        "message": "Cette option est liée au menu contextuel sur le bouton de la barre d'outils -> désactiver toutes les notifications -> période de temps personnalisée.",
+        "message": "Cette option est liée au menu contextuel du bouton de la barre d’outils -> Désactiver toutes les notifications -> Période de temps personnalisée",
         "description": ""
-    },
+  },
     "options_notifications_30": {
         "message": "Combiner toutes les notifications simultanées de bureau en une seule notification",
         "description": ""
-    },
+  },
     "options_notifications_31": {
-        "message": "Son de notification personnalisé",
+        "message": "Son personnalisé pour :",
         "description": ""
-    },
+  },
     "options_notifications_32": {
-        "message": "nom ou contenus d'e-mail",
+        "message": "nom ou contenus d’e-mail",
         "description": ""
-    },
+  },
     "options_notifications_33": {
-        "message": "titre des contenus d'e-mail",
+        "message": "titre des contenus d’e-mail",
         "description": ""
-    },
+  },
     "options_notifications_34": {
-        "message": "sommaire de contenus d'e-mail",
+        "message": "sommaire de contenus d’e-mail",
         "description": ""
-    },
-    "options_notifications_35": {
-        "message": "Pour sélectionner un nouveau son personnalisé, sélectionnez d'abord un son intégré, puis modifiez l'option en son personnalisé",
-        "description": ""
-    },
+  },
     "options_notifications_36": {
-        "message": "Demander à Gmail™ d'empêcher la redirection vers 'inbox.google.com'",
+        "message": "Demander à Gmail™ d’empêcher la redirection «inbox.google.com»",
         "description": ""
-    },
+  },
     "options_notifications_37": {
-        "message": "Afficher le numéro de badge",
+        "message": "Afficher le nombre d’e-mail non lus sur le badge (et choisir la couleur du badge)",
         "description": ""
-    },
+  },
     "options_notifications_38": {
         "message": "Actions plus rapides (marquer comme lu, supprimer, ...) (Considérer les actions à résoudre lorsque les en-têtes sont reçus)",
         "description": ""
-    },
+  },
     "options_notifications_40": {
-        "message": "Autoriser les actions rapides depuis la boîte de notification (deux actions maximum) (Chrome uniquement)",
+        "message": "Autoriser les actions rapides depuis la boîte de notification (deux actions maximum, pour Chrome uniquement)",
         "description": ""
-    },
+  },
     "options_notifications_41": {
         "message": "Marquer comme lu",
         "description": ""
-    },
+  },
     "options_notifications_42": {
         "message": "Archiver",
         "description": ""
-    },
+  },
     "options_notifications_43": {
-        "message": "Corbeille",
+        "message": "Supprimer",
         "description": ""
-    },
+  },
     "options_tab": {
-        "message": "Ouverture d'onglet :",
+        "message": "Ouverture d’onglet",
         "description": ""
-    },
+  },
     "options_tab_1": {
-        "message": "Chercher un compte Gmail™ ouvert seulement dans la fenêtre active",
+        "message": "Ne chercher un compte Gmail™ ouvert, que dans la fenêtre active",
         "description": ""
-    },
+  },
     "options_tab_2": {
-        "message": "Ne pas chercher les comptes Gmail™ ouverts dans les autres fenêtres du navigateur. Si Gmail™ n'est pas ouvert dans la fenêtre active, ouvrir un nouvel onglet.",
+        "message": "Ne pas chercher les comptes Gmail™ ouverts dans les autres fenêtres du navigateur. Si Gmail™ n’est pas ouvert dans la fenêtre active, ouvrir un nouvel onglet.",
         "description": ""
-    },
+  },
     "options_tab_3": {
-        "message": "Ouvrir un nouveau compte Gmail™ à côté de l'onglet actif",
+        "message": "Ouvrir le nouveau compte Gmail™ à côté de l’onglet actif",
         "description": ""
-    },
+  },
     "options_tab_4": {
-        "message": "Ouvrir un compte Gmail™ dans l'onglet actif",
+        "message": "Ouvrir le compte Gmail™ dans l’onglet actif",
         "description": ""
-    },
+  },
     "options_tab_5": {
-        "message": "Ouvrir un compte Gmail™ dans un onglet d'arrière-plan",
+        "message": "Ouvrir le compte Gmail™ dans un onglet d’arrière-plan",
         "description": ""
-    },
+  },
     "options_tab_6": {
-        "message": "Ouvrir un compte Gmail™ dans une nouvelle fenêtre",
+        "message": "Ouvrir le compte Gmail™ dans une nouvelle fenêtre",
         "description": ""
-    },
+  },
     "options_tab_7": {
-        "message": "Toujours utiliser des onglets vierges au lieu d'ouvrir un nouvel onglet quand ouvrir dans un onglet est activé.",
+        "message": "Toujours utiliser des onglets vierges au lieu d’ouvrir un nouvel onglet quand l’option ouvrir dans un onglet est activé",
         "description": ""
-    },
+  },
     "options_tab_8": {
         "message": "Ignorer les onglets Gmail™ ouverts",
         "description": ""
-    },
+  },
     "options_tab_9": {
-        "message": "Lorsque cette option est décochée, le notifieur Gmail™ vérifie la fenêtre active ou l'ensemble des fenêtres ouvertes pour l'instance en cours de Gmail™ et passe à l'onglet suivant lorsque l'ouverture d'onglet est demandée.",
+        "message": "Lorsque cette case est cochée, le notificateur ouvre les e-mails dans de nouveaux onglets du navigateur. Lorsque cette case n'est pas cochée, il recherchera d'abord dans la fenêtre active un onglet Gmail™ existant et y basculera. S'il n'est pas trouvé, il recherchera d'autres fenêtres ouvertes avant d'ouvrir un nouvel onglet.",
         "description": ""
-    },
+  },
     "options_tab_10": {
-        "message": "Ouvrir les emails en mode HTML basique",
+        "message": "Ouvrir les e-mails en mode HTML basique",
         "description": ""
-    },
+  },
+    "options_tab_11": {
+        "message": "Cliquer sur le titre d'un e-mail non lu ouvre Gmail™ sur l'e-mail lui-même au lieu d’ouvrir le dossier «Boîte de réception»",
+        "description": ""
+  },
     "options_toolbar": {
-        "message": "Barre d'outils :",
+        "message": "Barre d’outils",
         "description": ""
-    },
+  },
     "options_toolbar_1": {
-        "message": "Comportement du bouton de la barre d'outils",
+        "message": "Comportement du bouton de la barre d’outils",
         "description": ""
-    },
+  },
     "options_toolbar_2": {
-        "message": "Toujours ouvrir le panneau de prévisualisation d'e-mail",
+        "message": "Toujours ouvrir le panneau de prévisualisation d’e-mail",
         "description": ""
-    },
+  },
     "options_toolbar_3": {
-        "message": "Ouvrir un compte Gmail™ si un seul compte est connecté",
+        "message": "Ouvrir le compte Gmail™ si un seul compte est connecté",
         "description": ""
-    },
+  },
     "options_toolbar_18": {
-        "message": "Ouvrir un compte Gmail™(mode forcé)",
+        "message": "Ouvrir le compte Gmail™ (mode forcé)",
         "description": ""
-    },
+  },
     "options_toolbar_4": {
-        "message": "Mode du panneau de la barre d'outils",
+        "message": "Mode du panneau de la barre d’outils",
         "description": ""
-    },
+  },
     "options_toolbar_5": {
         "message": "Afficher le résumé uniquement",
         "description": ""
-    },
+  },
     "options_toolbar_6": {
         "message": "Afficher la totalité du contenu",
         "description": ""
-    },
+  },
     "options_toolbar_7": {
-        "message": "La largeur du panneau de la barre d'outils dans le mode \"contenu total\" est (en pixels) :",
+        "message": "Largeur du panneau de la barre d’outils dans le mode  «contenu total» (en pixels) :",
         "description": ""
-    },
+  },
     "options_toolbar_8": {
         "message": "La largeur minimale est de 500 pixels.",
         "description": ""
-    },
+  },
     "options_toolbar_9": {
-        "message": "La hauteur du panneau de la barre d'outils dans le mode \"contenu total\" est (en pixels) :",
+        "message": "La Hauteur du panneau de la barre d’outils dans le mode «contenu total» (en pixels) :",
         "description": ""
-    },
+  },
     "options_toolbar_10": {
         "message": "La hauteur minimale est de 500 pixels.",
         "description": ""
-    },
+  },
     "options_toolbar_11": {
-        "message": "Support des raccourcis clavier dans le panneau de la barre d'outils",
+        "message": "Support des raccourcis clavier dans le panneau de la barre d’outils",
         "description": ""
-    },
+  },
     "options_toolbar_12": {
-        "message": "! : Signaler comme spam, # : Mettre à la corbeille, e : Archiver, Shift + i : Marquer comme lu.",
+        "message": "Signaler comme spam : < ! >, Supprimer : < # >, Archiver  : < e >, Marquer comme lu : < Shift + i >.",
         "description": ""
-    },
+  },
     "options_toolbar_13": {
-        "message": "Rendre les e-mails en HTML dans le mode \"contenu total\"",
+        "message": "Rendu des e-mails en HTML dans le mode «contenu total»",
         "description": ""
-    },
+  },
     "options_toolbar_14": {
-        "message": "Si vous préférez le rendu \"texte uniquement\" dans le mode \"contenu total\", décochez cette case.",
+        "message": "Si vous préférez le rendu «texte uniquement» dans le mode «contenu total», décochez cette case.",
         "description": ""
-    },
+  },
     "options_toolbar_15": {
-        "message": "Cliquer avec le bouton du milieu sur bouton de la barre d'outils pour",
+        "message": "Cliquer avec le bouton du milieu sur l’icône de la barre d’outils pour",
         "description": ""
-    },
+  },
     "options_toolbar_16": {
         "message": "Rafraîchir tous les comptes",
         "description": ""
-    },
+  },
     "options_toolbar_17": {
-        "message": "Ouvrir le premier compte Gmail™",
+        "message": "Ouvrir le compte Gmail™ principal",
         "description": ""
-    },
+  },
     "options_misc": {
-        "message": "Divers :",
+        "message": "Divers",
         "description": ""
-    },
+  },
     "options_misc_1": {
         "message": "Trier les comptes par ordre alphabétique",
         "description": ""
-    },
+  },
     "options_misc_2": {
-        "message": "Le type de tri par défaut respecte l'ordre de connexions.",
+        "message": "Le type de tri par défaut respecte l’ordre de connexions.",
         "description": ""
-    },
+  },
     "options_misc_3": {
-        "message": "La légende de la barre d'outils est",
+        "message": "Légende de couleur du bouton de la barre d’outils :",
         "description": ""
-    },
+  },
     "options_misc_4": {
-        "message": "Couleur gris pour \"Tous lus\" et couleur bleu pour \"Déconnecté\"",
+        "message": "gris pour «Tous lus» et bleu pour «Déconnecté»",
         "description": ""
-    },
+  },
     "options_misc_5": {
-        "message": "Couleur bleu pour \"Tous lus\" et couleur gris pour \"Déconnecté\"",
+        "message": "bleu pour «Tous lus» et gris pour «Déconnecté»",
         "description": ""
-    },
+  },
     "options_misc_9": {
-        "message": "Couleur rouge pour \"Tous lus\" et couleur gris pour \"Déconnecté\"",
+        "message": "rouge pour «Tous lus» et gris pour «Déconnecté»",
         "description": ""
-    },
+  },
     "options_misc_6": {
-        "message": "Afficher une notification sur le bureau pour avertir que Gmail™ est déjà ouvert dans l'onglet actif",
+        "message": "Afficher une notification sur le bureau pour avertir que Gmail™ est déjà ouvert dans l’onglet actif",
         "description": ""
-    },
+  },
     "options_misc_7": {
         "message": "Afficher la page de bienvenue après une mise à jour",
         "description": ""
-    },
+  },
     "options_misc_8": {
         "message": "Réinitialiser tous les paramètres aux valeurs par défaut",
         "description": ""
-    },
+  },
     "options_misc_10": {
         "message": "Déclencher uniquement les notifications sonores et de bureau quand un e-mail est arrivé depuis moins de (en minutes) :",
         "description": ""
-    },
+  },
     "options_misc_11": {
-        "message": "En positionnant cette préférence à zéro, vous ne recevrez ni de notifications de bureau ni de notifications sonores ; néanmoins, vous recevrez toujours une notification de badge.",
+        "message": "En positionnant cette préférence à zéro, vous ne recevrez ni notifications de bureau ni notifications sonores ; néanmoins, vous recevrez toujours la notification de badge.",
         "description": ""
-    },
+  },
     "options_misc_12": {
-        "message": "Ne pas inclure de détails d'identifiant dans la bulle textuelle",
+        "message": "Ne pas inclure de détails d’identifiant dans la bulle textuelle",
         "description": ""
-    },
+  },
     "options_misc_13": {
-        "message": "Par défaut, le notifieur met à jour la bulle textuelle du bouton de la barre d'outils avec des infos d'identifiant. En désactivant cette option, la bulle textuelle restera à sa valeur par défaut.",
+        "message": "Par défaut, le notifieur met à jour la bulle textuelle du bouton de la barre d’outils avec des infos d’identifiant. En désactivant cette option, la bulle textuelle restera à sa valeur par défaut.",
         "description": ""
-    },
+  },
     "options_misc_14": {
-        "message": "Ne pas afficher le nombre badge exact quand le nombre d'e-mails non lus est supérieur à 999",
+        "message": "Ne pas afficher le nombre badge exact quand le nombre d’e-mails non lus est supérieur à 999",
         "description": ""
-    },
+  },
     "options_misc_15": {
         "message": "Ouvrir la page FAQ sur les mises à jour",
         "description": ""
-    },
-    "options_plugins": {
-        "message": "Plug-ins :",
+  },
+    "options_misc_16": {
+        "message": "Thème de couleur du panneau :",
         "description": ""
-    },
+  },
+    "options_misc_17": {
+        "message": "Thème clair",
+        "description": ""
+  },
+    "options_misc_18": {
+        "message": "Thème sombre",
+        "description": ""
+  },
+    "options_misc_19": {
+        "message": "Thème système",
+        "description": ""
+  },
+    "options_plugins": {
+        "message": "Plug-ins",
+        "description": ""
+  },
     "options_plugins_1": {
         "message": "Libellés Gmail™ et bouton étoile (expérimental)",
         "description": ""
-    },
+  },
     "options_plugins_2": {
         "message": "Ce plugin affiche le bouton étoile ainsi que les libellés des fils de discussion dans la fenêtre contextuelle (mode étendu uniquement).",
         "description": ""
-    },
+  },
     "options_px": {
         "message": "pixel(s)",
         "description": ""
-    },
+  },
     "options_empty": {
         "message": "non défini",
         "description": ""
-    },
+  },
     "options_button_test": {
-        "message": "Jouer",
+        "message": "Jouer le son ►",
         "description": ""
-    },
+  },
     "options_button_reset": {
-        "message": "RàZ des préférences",
+        "message": "Remise à zéro des préférences",
         "description": ""
-    },
+  },
     "popup_settings": {
-        "message": "paramètres",
+        "message": "Paramètres",
         "description": ""
-    },
+  },
     "popup_of": {
         "message": "sur",
         "description": ""
-    },
+  },
     "popup_wait": {
         "message": "Patientez...",
         "description": ""
-    },
+  },
     "popup_date_format": {
-        "message": "%dd %mm %yy",
+        "message": "%mm %jj %aa",
         "description": ""
-    },
+  },
     "popup_no_subject": {
         "message": "(aucun objet)",
         "description": ""
-    },
+  },
     "popup_open_settings": {
-        "message": "Ouvrir les paramètres",
+        "message": "Paramètres",
         "description": ""
-    },
+  },
     "popup_open_inbox": {
-        "message": "Ouvrir la boîte de réception",
+        "message": "Boîte de réception",
         "description": ""
-    },
+  },
     "popup_archive": {
-        "message": "Archive",
+        "message": "Archiver",
         "description": ""
-    },
+  },
     "popup_spam": {
-        "message": "Spam",
+        "message": "Spam !",
         "description": ""
-    },
+  },
     "popup_trash": {
-        "message": "Corbeille",
+        "message": "Supprimer",
         "description": ""
-    },
+  },
     "popup_refresh": {
         "message": "Rafraîchir",
         "description": ""
-    },
+  },
     "popup_read": {
         "message": "Marquer comme lu",
         "description": ""
-    },
+  },
     "popup_read_all": {
         "message": "Tout marquer comme lu",
         "description": ""
-    },
-    "popup_msg_1": {
-        "message": "à l'instant",
+  },
+    "popup_toggle_dark": {
+        "message": "Thème sombre <=> Thème clair",
         "description": ""
-    },
+  },
+    "popup_msg_1": {
+        "message": "à l’instant",
+        "description": ""
+  },
     "popup_msg_2": {
         "message": "1 minute plus tôt",
         "description": ""
-    },
+  },
     "popup_msg_3_format": {
         "message": "%d minutes plus tôt",
         "description": ""
-    },
+  },
     "popup_msg_4": {
         "message": "1 heure plus tôt",
         "description": ""
-    },
+  },
     "popup_msg_5": {
         "message": "heures plus tôt",
         "description": ""
-    },
+  },
     "popup_msg_6": {
         "message": "Hier",
         "description": ""
-    },
+  },
     "popup_msg_7_format": {
         "message": "%d jours plus tôt",
         "description": ""
-    },
+  },
     "popup_msg_8_format": {
         "message": "%d semaines plus tôt",
         "description": ""
-    },
+  },
     "popup_msg_9_format": {
         "message": "%d mois plus tôt",
         "description": ""
-    },
+  },
     "popup_msg_10": {
         "message": "Janvier",
         "description": ""
-    },
+  },
     "popup_msg_11": {
         "message": "Février",
         "description": ""
-    },
+  },
     "popup_msg_12": {
         "message": "Mars",
         "description": ""
-    },
+  },
     "popup_msg_13": {
         "message": "Avril",
         "description": ""
-    },
+  },
     "popup_msg_14": {
         "message": "Mai",
         "description": ""
-    },
+  },
     "popup_msg_15": {
         "message": "Juin",
         "description": ""
-    },
+  },
     "popup_msg_16": {
         "message": "Juillet",
         "description": ""
-    },
+  },
     "popup_msg_17": {
         "message": "Août",
         "description": ""
-    },
+  },
     "popup_msg_18": {
         "message": "Septembre",
         "description": ""
-    },
+  },
     "popup_msg_19": {
         "message": "Octobre",
         "description": ""
-    },
+  },
     "popup_msg_20": {
         "message": "Novembre",
         "description": ""
-    },
+  },
     "popup_msg_21": {
         "message": "Décembre",
         "description": ""
-    },
+  },
     "settings_open_title": {
-        "message": "Ouvrir la page options (paramètres)",
+        "message": "Ouvrir la page des options (paramètres)",
         "description": ""
-    },
+  },
     "settings_open_label": {
         "message": "Ouvrir les options",
         "description": ""
-    }
+  }
 }

--- a/v3.classic/_locales/fr/messages.json
+++ b/v3.classic/_locales/fr/messages.json
@@ -1,4 +1,8 @@
 {
+    "gmail": {
+        "message": "Notifieur pour Gmail™",
+        "description": ""
+    },
     "toolbar_label": {
         "message": "Notifieur pour Gmail™",
         "description": ""
@@ -749,10 +753,6 @@
     },
     "settings_open_label": {
         "message": "Ouvrir les options",
-        "description": ""
-    },
-    "gmail": {
-        "message": "Notifieur pour Gmail™",
         "description": ""
     }
 }


### PR DESCRIPTION
Hi

just a little harmonization between the order of the elements between Github and Transifex.

PS: I updated the translation on Transifex from the new "message.json" version (en) file but I don't know if I should create the "message.json" version (fr) file from the "for_use_gmail-notifier-addon_messagesjson-v3_fr_FR.json" file that I downloaded from Transifex, by adding the missing lines and characters to have the format used on Github. I hope I am clear in my question, namely do you want me to update the Github file with the latest version or do you prefer to do it yourself?